### PR TITLE
Apply dark theme and remove unused buttons

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -1,11 +1,20 @@
 /* Custom premium refresh overrides */
 :root {
-  --color-bg: #ffffff;
-  --color-text: #111827;
-  --color-primary: #2563eb;
-  --color-primary-hover: #1e40af;
+  --color-bg: #263886;
+  --color-text: #8083ab;
+  --color-primary: #9f203e;
+  --color-primary-hover: #713365;
   --radius: 0.5rem;
+  --border-radius: var(--radius);
   --transition: 0.3s ease;
+
+  /* Override existing palette to use only approved colors */
+  --black: #263886;
+  --white: #8083ab;
+  --secondary: #713365;
+  --primary: #9f203e;
+  --light-gray: #8083ab;
+  --dark-gray: #713365;
 }
 
 html {
@@ -62,7 +71,7 @@ img {
   min-height: 44px;
   font-size: 1rem;
   background-color: var(--color-primary);
-  color: #fff;
+  color: var(--color-text);
   border-radius: var(--radius);
   transition: background-color var(--transition), transform var(--transition);
   touch-action: manipulation;
@@ -88,6 +97,42 @@ img {
 .fade-in.visible {
   opacity: 1;
   transform: none;
+}
+
+/* Ensure consistent rounded borders and palette usage */
+[class*="card"],
+.button,
+.w-nav,
+.w-container,
+.section,
+.hero-block,
+.navbar_outline {
+  border-radius: var(--radius);
+}
+
+body,
+.w-nav,
+.w-container,
+.section,
+.hero-block,
+.navbar_outline {
+  background-color: var(--color-bg);
+  color: var(--color-text);
+}
+
+.service-card {
+  background-color: var(--color-primary);
+  background-image: none;
+  color: var(--color-text);
+}
+
+.service-card:hover {
+  background-color: var(--color-primary-hover);
+}
+
+.service-card-title,
+.service-card-paragraph {
+  color: var(--color-text);
 }
 
 .service-card {

--- a/index.html
+++ b/index.html
@@ -68,10 +68,6 @@
               <h5 class="heading-2">high performance<br>athletes coached</h5>
             </div>
           </div>
-          <div class="hero-cta-group">
-            <a href="#contact" class="button w-button">Book Call</a>
-            <a href="https://wa.me/" target="_blank" class="button w-button">WhatsApp</a>
-          </div>
         </div>
         <div class="hero-image-wrapper slide-from-left-animation fade-in">
           <div class="cut-out-flex align-bottom"></div><img src="images/Rifa-Sports-banner-1.webp" loading="lazy" decoding="async" width="512" sizes="(max-width: 767px) 100vw, 511.9921875px" alt="" srcset="images/Rifa-Sports-banner-1-p-500.webp 500w, images/Rifa-Sports-banner-1-p-800.webp 800w, images/Rifa-Sports-banner-1.webp 1024w" class="hero-image">


### PR DESCRIPTION
## Summary
- Switch site to a dark color scheme constrained to the provided palette
- Remove WhatsApp and Book Call buttons from the hero section
- Standardize rounded corners across common layout elements

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9bc7c83c8320b5baa9b128384119