### PR TITLE
Ensure hero section renders without JavaScript

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -95,15 +95,20 @@ img {
 }
 
 .fade-in {
-  opacity: 0;
-  transform: translateY(20px);
+  opacity: 1;
+  transform: none;
   transition:
     opacity var(--transition),
     transform var(--transition);
   will-change: opacity, transform;
 }
 
-.fade-in.visible {
+html.js .fade-in {
+  opacity: 0;
+  transform: translateY(20px);
+}
+
+html.js .fade-in.visible {
   opacity: 1;
   transform: none;
 }

--- a/js/custom.js
+++ b/js/custom.js
@@ -1,4 +1,5 @@
 // Minimal fade-in on scroll
+document.documentElement.classList.add("js");
 document.addEventListener("DOMContentLoaded", () => {
   const elements = document.querySelectorAll(".fade-in");
   const prefersReducedMotion = window.matchMedia(


### PR DESCRIPTION
## Summary
- Show hero content even when JavaScript fails by defaulting fade-in elements to visible.
- Add JS hook to apply animations only when scripting is enabled.

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68baa20b7f548320be5e79fdf9d33095